### PR TITLE
Amanecidas Quest NG implementation

### DIFF
--- a/IterTormenti/AmanecidasPatches.cs
+++ b/IterTormenti/AmanecidasPatches.cs
@@ -1,44 +1,10 @@
 using HarmonyLib;
-using Blasphemous.Framework.Levels;
 using Framework.Managers;
-using System;
 using Tools.Playmaker2.Action;
 using Gameplay.UI;
 
 namespace IterTormenti
 {
-    [HarmonyPatch(typeof(LevelFramework), "CheckCondition")]
-    public class LevelFrameworkCheckCondition_Patch
-    {
-        public static bool Postfix(bool originalResult, string condition)
-        {
-            if (string.IsNullOrEmpty(condition))
-                return originalResult;
-
-            int colon = condition.IndexOf(':');
-            string conditionType = condition.Substring(0, colon);
-            string conditionValue = condition.Substring(colon + 1);
-
-            if (conditionType == "gamemode")
-            {
-                GameModeManager.GAME_MODES gameMode;
-                try
-                {
-                    gameMode = (GameModeManager.GAME_MODES)Enum.Parse(typeof(GameModeManager.GAME_MODES), conditionValue);
-                }
-                catch(Exception)
-                {
-                    Main.IterTormenti.LogError("LevelFrameworkCheckCondition_Patch: Invalid game mode value: " + conditionValue);
-                    return originalResult;
-                }
-                
-                return Core.GameModeManager.IsCurrentMode(gameMode);
-            }
-            
-            return originalResult;
-        }
-    }
-
     [HarmonyPatch(typeof(CheckGameModeActive), nameof(CheckGameModeActive.OnEnter))]
     class CheckGameModeActiveOnEnter_Patch
     {
@@ -67,6 +33,7 @@ namespace IterTormenti
                 return true;
             }
 
+            // TODO: Using this to detect all FSMs doing the check during testing, remove when done
             UIController.instance.ShowPopUp( __instance.Owner.name + " is checking for NG+",
                                              "", 3f, false);
 
@@ -104,16 +71,20 @@ namespace IterTormenti
                 case "Deosgracias":
                 case "DeograciasControl":
                 {
-                    // There might be other Deosgracias controllers around, and this only applies to
-                    // this specific scene (Holy Line, over the Petrous entrance), so skip if we are 
-                    // somewhere else
-                    if( "D01Z01S01" != Core.LevelManager.currentLevel.LevelName ) return true;
+                    // TODO: Deogracias might only check NG+ give Amanecidas lore, so we might not need to
+                    //       add special conditions... investigating
+
+                    // // There might be other Deosgracias controllers around, and this only applies to
+                    // // this specific scene (Holy Line, over the Petrous entrance), so skip if we are 
+                    // // somewhere else
+                    // if(    "D01Z01S01" != Core.LevelManager.currentLevel.LevelName
+                    //     && "D08Z01S01" != Core.LevelManager.currentLevel.LevelName ) return true; // TODO: Allow check on bridge until we know what it does
 
                     // Until we've spoken with Jibrael, Deogracias won't show up anyway, so skip
                     if( !Core.Events.GetFlag("SANTOS_FIRSTCONVERSATION_DONE") ) return true;
                     
-                    // Once we're done with Deogracias and his bewilderment, we can skip
-                    if( Core.Events.GetFlag("DEOSGRACIAS_SANTOS_DONE") ) return true;
+                    // // Once we're done with Deogracias and his bewilderment, we can skip
+                    // if( Core.Events.GetFlag("DEOSGRACIAS_SANTOS_DONE") ) return true;
                     
                     break;
                 }

--- a/IterTormenti/AmanecidasPatches.cs
+++ b/IterTormenti/AmanecidasPatches.cs
@@ -1,0 +1,137 @@
+using HarmonyLib;
+using Blasphemous.Framework.Levels;
+using Framework.Managers;
+using System;
+using Tools.Playmaker2.Action;
+using Gameplay.UI;
+
+namespace IterTormenti
+{
+    [HarmonyPatch(typeof(LevelFramework), "CheckCondition")]
+    public class LevelFrameworkCheckCondition_Patch
+    {
+        public static bool Postfix(bool originalResult, string condition)
+        {
+            if (string.IsNullOrEmpty(condition))
+                return originalResult;
+
+            int colon = condition.IndexOf(':');
+            string conditionType = condition.Substring(0, colon);
+            string conditionValue = condition.Substring(colon + 1);
+
+            if (conditionType == "gamemode")
+            {
+                GameModeManager.GAME_MODES gameMode;
+                try
+                {
+                    gameMode = (GameModeManager.GAME_MODES)Enum.Parse(typeof(GameModeManager.GAME_MODES), conditionValue);
+                }
+                catch(Exception)
+                {
+                    Main.IterTormenti.LogError("LevelFrameworkCheckCondition_Patch: Invalid game mode value: " + conditionValue);
+                    return originalResult;
+                }
+                
+                return Core.GameModeManager.IsCurrentMode(gameMode);
+            }
+            
+            return originalResult;
+        }
+    }
+
+    [HarmonyPatch(typeof(CheckGameModeActive), nameof(CheckGameModeActive.OnEnter))]
+    class CheckGameModeActiveOnEnter_Patch
+    {
+        protected static string LOG_HEADER = nameof(CheckGameModeActive) + "::" + nameof(CheckGameModeActive.OnEnter) + "::Patch: ";
+
+        /// <summary>
+        /// This prefix will deceive FSMs asking for the current gamemode, by stating we're on
+        /// NEW_GAME_PLUS when we're actually in NEW_GAME.
+        /// The purpose is to make sure that the FSMs managing the Amanecidas questline work 
+        /// properly, as they will be deactivated when not in NEW_GAME_PLUS.
+        /// Unfortunately, this can cause a lot of overhead for all other checks for the
+        /// current game state, as well as unpredictable behaviour for checks that should
+        /// NOT be in NG+, as such, we will attempt to "fail" and return to the original method
+        /// as early as possible by checking the specific conditions where this modification makes sense.        
+        /// </summary>
+        /// <param name="__instance">We need instance specific data</param>
+        /// <returns>'true' to return to the original method, 'false' to skip it</returns>
+        public static bool Prefix(CheckGameModeActive __instance)
+        {           
+            Main.IterTormenti.Log(LOG_HEADER + __instance.Owner.name + " is checking for game mode: " + __instance.mode.Value);
+            
+            // Only care if the FSM is asking for NEW_GAME_PLUS
+            if ( __instance.mode.Value != "NEW_GAME_PLUS" )
+            {                
+                Main.IterTormenti.Log(LOG_HEADER + "Only care if the FSM is asking for NEW_GAME_PLUS");
+                return true;
+            }
+
+            UIController.instance.ShowPopUp( __instance.Owner.name + " is checking for NG+",
+                                             "", 3f, false);
+
+
+            // Only perform these operations when playing in NEW_GAME
+            if( Core.GameModeManager.GetCurrentGameMode() != GameModeManager.GAME_MODES.NEW_GAME )
+            {                
+                Main.IterTormenti.Log(LOG_HEADER + "Only perform these operations when playing in NEW_GAME");
+                return true;
+            }
+
+            // Check the identity of the FSM asking for the gamemode, and act accordingly
+            switch( __instance.Owner.name )
+            {
+                case "LaudesTomb": // Manages the tomb breaking, should be enabled just like Jibrael
+                case "Santos": // FSM that manages Jibrael encounters (Apparently, he was originally named Santos)
+                {
+                    // If Petrous is closed, we don't want to bother Jibrael
+                    if( !Core.Events.GetFlag("SANTOS_DOOR_OPENED") ) return true;
+
+                    // Jibrael's bell bushes and tomb remain after completing the quest, so we need 
+                    // to override his checks forever
+
+                    break;
+                }
+                case "JibraelCaveTrigger":
+                case "JibraelCaveTriggerStop":
+                {
+                    // If the Player doesn't have the Petrified Bell there is no point in waking up
+                    // the FSMs that control the bell vibrating
+                    if( !Core.InventoryManager.IsQuestItemOwned("QI106") ) return true;
+
+                    break;
+                }
+                case "Deosgracias":
+                case "DeograciasControl":
+                {
+                    // There might be other Deosgracias controllers around, and this only applies to
+                    // this specific scene (Holy Line, over the Petrous entrance), so skip if we are 
+                    // somewhere else
+                    if( "D01Z01S01" != Core.LevelManager.currentLevel.LevelName ) return true;
+
+                    // Until we've spoken with Jibrael, Deogracias won't show up anyway, so skip
+                    if( !Core.Events.GetFlag("SANTOS_FIRSTCONVERSATION_DONE") ) return true;
+                    
+                    // Once we're done with Deogracias and his bewilderment, we can skip
+                    if( Core.Events.GetFlag("DEOSGRACIAS_SANTOS_DONE") ) return true;
+                    
+                    break;
+                }
+                default:
+                {
+                    Main.IterTormenti.Log(LOG_HEADER + " '" + __instance.Owner.name + "'? Who art thou? Begone! To the default implementation with you!");
+                    return true; // Who art thou? Begone! To the default implementation with you!
+                }
+            }
+
+            // TODO: Amanecidas boss fights <- "AmanecidaBossLogic" does not call this method, nothing to do?
+            // TODO: Laudes combat <- Laudes doesn't care, combat starts if you enter her room, nothing to do?           
+
+            Main.IterTormenti.Log(LOG_HEADER + "DECEIVING");           
+
+            __instance.Fsm.Event(__instance.modeIsActive); // Tell falsehoods to the FSM
+            __instance.Finish();
+            return false;
+        }
+    }
+}

--- a/IterTormenti/AmanecidasPatches.cs
+++ b/IterTormenti/AmanecidasPatches.cs
@@ -1,7 +1,6 @@
 using HarmonyLib;
 using Framework.Managers;
 using Tools.Playmaker2.Action;
-using Gameplay.UI;
 
 namespace IterTormenti
 {
@@ -24,31 +23,18 @@ namespace IterTormenti
         /// <returns>'true' to return to the original method, 'false' to skip it</returns>
         public static bool Prefix(CheckGameModeActive __instance)
         {           
-            Main.IterTormenti.Log(LOG_HEADER + __instance.Owner.name + " is checking for game mode: " + __instance.mode.Value);
-            
             // Only care if the FSM is asking for NEW_GAME_PLUS
             if ( __instance.mode.Value != "NEW_GAME_PLUS" )
-            {                
-                Main.IterTormenti.Log(LOG_HEADER + "Only care if the FSM is asking for NEW_GAME_PLUS");
                 return true;
-            }
-
-            // TODO: Using this to detect all FSMs doing the check during testing, remove when done
-            UIController.instance.ShowPopUp( __instance.Owner.name + " is checking for NG+",
-                                             "", 3f, false);
-
 
             // Only perform these operations when playing in NEW_GAME
             if( Core.GameModeManager.GetCurrentGameMode() != GameModeManager.GAME_MODES.NEW_GAME )
-            {                
-                Main.IterTormenti.Log(LOG_HEADER + "Only perform these operations when playing in NEW_GAME");
                 return true;
-            }
 
             // Check the identity of the FSM asking for the gamemode, and act accordingly
             switch( __instance.Owner.name )
             {
-                case "LaudesTomb": // Manages the tomb breaking, should be enabled just like Jibrael
+                case "LaudesTomb": // Manages the glass tomb breaking, should be enabled just like Jibrael
                 case "Santos": // FSM that manages Jibrael encounters (Apparently, he was originally named Santos)
                 {
                     // If Petrous is closed, we don't want to bother Jibrael
@@ -71,34 +57,21 @@ namespace IterTormenti
                 case "Deosgracias":
                 case "DeograciasControl":
                 {
-                    // TODO: Deogracias might only check NG+ give Amanecidas lore, so we might not need to
-                    //       add special conditions... investigating
-
-                    // // There might be other Deosgracias controllers around, and this only applies to
-                    // // this specific scene (Holy Line, over the Petrous entrance), so skip if we are 
-                    // // somewhere else
-                    // if(    "D01Z01S01" != Core.LevelManager.currentLevel.LevelName
-                    //     && "D08Z01S01" != Core.LevelManager.currentLevel.LevelName ) return true; // TODO: Allow check on bridge until we know what it does
-
-                    // Until we've spoken with Jibrael, Deogracias won't show up anyway, so skip
+                    // Deogracias only checks NG+ to give Amanecidas lore, so once Jibrael has been spoken
+                    // to for the first time, we keep checking for his actions
                     if( !Core.Events.GetFlag("SANTOS_FIRSTCONVERSATION_DONE") ) return true;
-                    
-                    // // Once we're done with Deogracias and his bewilderment, we can skip
-                    // if( Core.Events.GetFlag("DEOSGRACIAS_SANTOS_DONE") ) return true;
-                    
+
+                    // TODO: Minor optimization, stop checking for Deogracias requests once his last conversation is done
+
                     break;
                 }
                 default:
                 {
-                    Main.IterTormenti.Log(LOG_HEADER + " '" + __instance.Owner.name + "'? Who art thou? Begone! To the default implementation with you!");
                     return true; // Who art thou? Begone! To the default implementation with you!
                 }
             }
 
-            // TODO: Amanecidas boss fights <- "AmanecidaBossLogic" does not call this method, nothing to do?
-            // TODO: Laudes combat <- Laudes doesn't care, combat starts if you enter her room, nothing to do?           
-
-            Main.IterTormenti.Log(LOG_HEADER + "DECEIVING");           
+            // The Amanecidas & Laudes boss fights don't care if we're on NG+ or not
 
             __instance.Fsm.Event(__instance.modeIsActive); // Tell falsehoods to the FSM
             __instance.Finish();

--- a/IterTormenti/IterTormenti.csproj
+++ b/IterTormenti/IterTormenti.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Blasphemous.ModdingAPI" Version="2.1.0" />
     <PackageReference Include="Blasphemous.Framework.Penitence" Version="0.2.0" />
-    <PackageReference Include="Blasphemous.Framework.Levels" Version="0.1.0" />
+    <PackageReference Include="Blasphemous.Framework.Levels" Version="0.1.1" />
     <PackageReference Include="Blasphemous.ModdingReferences" Version="4.0.67" />
   </ItemGroup>
 

--- a/IterTormenti/IterTormenti.csproj
+++ b/IterTormenti/IterTormenti.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Blasphemous.ModdingAPI" Version="2.1.0" />
     <PackageReference Include="Blasphemous.Framework.Penitence" Version="0.2.0" />
+    <PackageReference Include="Blasphemous.Framework.Levels" Version="0.1.0" />
     <PackageReference Include="Blasphemous.ModdingReferences" Version="4.0.67" />
   </ItemGroup>
 
@@ -38,7 +39,7 @@
 
     <!-- Copy plugin & resources to development folder -->
     <PropertyGroup>
-      <DevFolder>C:\DEV\MOD\Blasphemous\Workspace\Blasphemous_Modded\Modding\</DevFolder>
+      <DevFolder>YOUR_MODDED_BLASPHEMOUS_PATH</DevFolder>
     </PropertyGroup>
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(DevFolder)plugins" />
     <Copy SourceFiles="@(DataDlls)" DestinationFolder="$(DevFolder)data" />

--- a/IterTormenti/Main.cs
+++ b/IterTormenti/Main.cs
@@ -5,7 +5,7 @@ namespace IterTormenti
     [BepInPlugin(ModInfo.MOD_ID, ModInfo.MOD_NAME, ModInfo.MOD_VERSION)]
     [BepInDependency("Blasphemous.ModdingAPI", "2.1.0")]
     [BepInDependency("Blasphemous.Framework.Penitence", "0.2.0")]
-    [BepInDependency("Blasphemous.Framework.Levels", "0.1.0")]
+    [BepInDependency("Blasphemous.Framework.Levels", "0.1.1")]
     public class Main : BaseUnityPlugin
     {
         public static Main Instance { get; private set; }

--- a/IterTormenti/Main.cs
+++ b/IterTormenti/Main.cs
@@ -5,6 +5,7 @@ namespace IterTormenti
     [BepInPlugin(ModInfo.MOD_ID, ModInfo.MOD_NAME, ModInfo.MOD_VERSION)]
     [BepInDependency("Blasphemous.ModdingAPI", "2.1.0")]
     [BepInDependency("Blasphemous.Framework.Penitence", "0.2.0")]
+    [BepInDependency("Blasphemous.Framework.Levels", "0.1.0")]
     public class Main : BaseUnityPlugin
     {
         public static Main Instance { get; private set; }

--- a/IterTormenti/PenitencePatches.cs
+++ b/IterTormenti/PenitencePatches.cs
@@ -12,7 +12,7 @@ using UnityEngine.UI;
 
 namespace IterTormenti
 {
-    // Disable penitence completion medals for for combo penitences
+    // Disable penitence completion medals for combo penitences
     [HarmonyPatch(typeof(PenitenceSlot), "UpdateFromSavegameData")]
     class PenitenceSlotUpdateFromSavegameData_Patch
     {

--- a/resources/levels/Iter Tormenti/D17Z01S01.json
+++ b/resources/levels/Iter Tormenti/D17Z01S01.json
@@ -1,0 +1,13 @@
+{
+    "additions": [
+        {
+            "type": "item-ground",
+            "id": "QI106",
+            "position": {
+                "x": -1003.65,
+                "y": 14
+            },
+            "condition": "gamemode:NEW_GAME"
+        }
+    ]
+}


### PR DESCRIPTION
This update implements the Amanecidas Quest in NG, via the following:

- The Petrified Bell can now be found in the world and picked up
- The Amanecidas Quest events will now work in NG

Note: The current Petrified Bell location is a placeholder, pending a bug fix in the Levels framework